### PR TITLE
refactor: refactor bad smell UnnecessaryToStringCall

### DIFF
--- a/tck/optional/src/main/java/org/eclipse/microprofile/metrics/test/optional/MPMetricBaseMetricsTest.java
+++ b/tck/optional/src/main/java/org/eclipse/microprofile/metrics/test/optional/MPMetricBaseMetricsTest.java
@@ -212,10 +212,10 @@ public class MPMetricBaseMetricsTest {
 
                 if (tmp[2].startsWith(promName)) {
                     found = true;
-                    assertEquals("Expected [" + mm.toString() + "] got [" + line + "]", tmp[3], mm.type);
+                    assertEquals("Expected [" + mm + "] got [" + line + "]", tmp[3], mm.type);
                 }
             }
-            assertTrue("Not found [" + mm.toString() + "]", found);
+            assertTrue("Not found [" + mm + "]", found);
 
         }
     }
@@ -425,3 +425,5 @@ public class MPMetricBaseMetricsTest {
     }
 
 }
+
+

--- a/tck/optional/src/main/java/org/eclipse/microprofile/metrics/test/optional/MPMetricBaseMetricsTest.java
+++ b/tck/optional/src/main/java/org/eclipse/microprofile/metrics/test/optional/MPMetricBaseMetricsTest.java
@@ -425,5 +425,3 @@ public class MPMetricBaseMetricsTest {
     }
 
 }
-
-

--- a/tck/optional/src/main/java/org/eclipse/microprofile/metrics/test/optional/MetricAppBeanOptional.java
+++ b/tck/optional/src/main/java/org/eclipse/microprofile/metrics/test/optional/MetricAppBeanOptional.java
@@ -194,7 +194,7 @@ public class MetricAppBeanOptional {
                 Thread.sleep(5000);
                 asyncResponse.resume("This is a GET request with AsyncResponse");
             } catch (Exception e) {
-                System.err.println(e.toString());
+                System.err.println(e);
             }
         });
         thread.start();
@@ -250,3 +250,4 @@ public class MetricAppBeanOptional {
     }
 
 }
+

--- a/tck/optional/src/main/java/org/eclipse/microprofile/metrics/test/optional/MetricAppBeanOptional.java
+++ b/tck/optional/src/main/java/org/eclipse/microprofile/metrics/test/optional/MetricAppBeanOptional.java
@@ -250,4 +250,3 @@ public class MetricAppBeanOptional {
     }
 
 }
-


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
<!-- fingerprint:Qodana-microprofile-metrics-UnnecessaryToStringCall-a60885e0d15570ecf5010b4d286b5ee5eabe858a-sl:215-el:0-sc:52-ec:0-co:8358-cl:8 -->
<!-- fingerprint:Qodana-microprofile-metrics-UnnecessaryToStringCall-a60885e0d15570ecf5010b4d286b5ee5eabe858a-sl:218-el:0-sc:43-ec:0-co:8487-cl:8 -->
<!-- fingerprint:Qodana-microprofile-metrics-UnnecessaryToStringCall-a60885e0d15570ecf5010b4d286b5ee5eabe858a-sl:197-el:0-sc:38-ec:0-co:6576-cl:8 -->
# Repairing Code Style Issues
* UnnecessaryToStringCall (3)
